### PR TITLE
Get raw repo url from base repo url

### DIFF
--- a/vcsurl.go
+++ b/vcsurl.go
@@ -182,6 +182,15 @@ func GetRawRoot(url *url.URL) *url.URL {
 			url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1/"))
 			return url
 		}
+	} else {
+		if url.Host == "github.com" {
+			//strip .git if present
+			url.Path = strings.TrimSuffix(url.Path, ".git")
+
+			re := regexp.MustCompile("^https://github.com/([^/]+)/([^/]+)$")
+			url, _ := url.Parse(re.ReplaceAllString(url.String(), "https://raw.githubusercontent.com/$1/$2/master/"))
+			return url
+		}
 	}
 	return nil
 }

--- a/vcsurl_test.go
+++ b/vcsurl_test.go
@@ -21,9 +21,11 @@ func TestGitHub(t *testing.T) {
 	AssertEqual(t, IsRepo(url), true)
 	AssertEqual(t, IsAccount(url), false)
 	AssertEqual(t, GetRepo(url).String(), url.String())
+	AssertEqual(t, GetRawRoot(url).String(), "https://raw.githubusercontent.com/alranel/go-vcsurl/master/")
 
 	url, _ = url.Parse("https://github.com/alranel/go-vcsurl.git")
 	AssertEqual(t, GetRepo(url).String(), "https://github.com/alranel/go-vcsurl")
+	AssertEqual(t, GetRawRoot(url).String(), "https://raw.githubusercontent.com/alranel/go-vcsurl/master/")
 
 	url, _ = url.Parse("https://github.com/alranel/go-vcsurl/blob/master/README.md")
 	AssertEqual(t, IsFile(url), true)


### PR DESCRIPTION
This could be useful to get the base raw repo url from a full repository URL. Only for github at the moment.