### PR TITLE
Support GitLab's new style routes.

### DIFF
--- a/vcsurl.go
+++ b/vcsurl.go
@@ -116,7 +116,7 @@ func IsFile(url *url.URL) bool {
 			return true
 		}
 	} else if IsGitLab(url) {
-		if ok, _ := regexp.MatchString("^(/[^/]+)+/blob/[^/]+/.+$", url.Path); ok {
+		if ok, _ := regexp.MatchString("^(/[^/]+)+/(-/)?blob/[^/]+/.+$", url.Path); ok {
 			return true
 		}
 	}
@@ -136,7 +136,7 @@ func IsRawFile(url *url.URL) bool {
 			return true
 		}
 	} else if IsGitLab(url) {
-		if ok, _ := regexp.MatchString("^(/[^/]+)+/raw/[^/]+/.+$", url.Path); ok {
+		if ok, _ := regexp.MatchString("^(/[^/]+)+/(-/)?raw/[^/]+/.+$", url.Path); ok {
 			return true
 		}
 	}
@@ -158,7 +158,7 @@ func GetRawFile(url *url.URL) *url.URL {
 		url, _ := url.Parse(re.ReplaceAllString(url.String(), "https://bitbucket.org/$1/$2/raw/$3"))
 		return url
 	} else if IsGitLab(url) {
-		re := regexp.MustCompile("^(https://.+?(?:/[^/]+)+)/blob/([^/]+/.+)$")
+		re := regexp.MustCompile("^(https?://.+?(?:/[^/]+)+?)/(?:-/)?blob/([^/]+/.+)$")
 		url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1/raw/$2"))
 		return url
 	}
@@ -178,7 +178,7 @@ func IsRawRoot(url *url.URL) bool {
 			return true
 		}
 	} else if IsGitLab(url) {
-		if ok, _ := regexp.MatchString("^(/[^/]+)+/raw/[^/]+/?$", url.Path); ok {
+		if ok, _ := regexp.MatchString("^(/[^/]+)+/(-/)?raw/[^/]+/?$", url.Path); ok {
 			return true
 		}
 	}
@@ -198,7 +198,7 @@ func GetRawRoot(url *url.URL) *url.URL {
 			url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1/"))
 			return url
 		} else if IsGitLab(url) {
-			re := regexp.MustCompile("^(https://.+?(?:/[^/]+)+/raw/[^/]+).*$")
+			re := regexp.MustCompile("^(https?://.+?(?:/[^/]+)+/(-/)?raw/[^/]+).*$")
 			url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1/"))
 			return url
 		}
@@ -234,7 +234,7 @@ func GetRepo(url *url.URL) *url.URL {
 			url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1"))
 			return url
 		} else if IsGitLab(url) {
-			re := regexp.MustCompile("^(https://.+?(?:/[^/]+)+?)/raw/.*$")
+			re := regexp.MustCompile("^(https?://.+?(?:/[^/]+)+?)/(-/)?raw/.*$")
 			url, _ := url.Parse(re.ReplaceAllString(url.String(), "$1"))
 			return url
 		}

--- a/vcsurl_test.go
+++ b/vcsurl_test.go
@@ -100,8 +100,41 @@ func TestGitLab(t *testing.T) {
 	AssertEqual(t, GetRepo(url).String(), "https://gitlab.com/gitlab-org/gitlab-services/design.gitlab.com")
 	AssertEqual(t, GetRepo(GetRawRoot(url)).String(), "https://gitlab.com/gitlab-org/gitlab-services/design.gitlab.com")
 
+	// Self hosted GitLab
 	url, _ = url.Parse("https://dev.funkwhale.audio/funkwhale/ansible")
 	AssertEqual(t, IsGitLab(url), true)
+
+	// Self hosted GitLab with HTTP URL and paths namespaced with '-'.
+	url, _ = url.Parse("http://dev.funkwhale.audio/funkwhale/ansible/-/blob/master/README.md")
+	AssertEqual(t, IsGitLab(url), true)
+	AssertEqual(t, IsRepo(url), false)
+	AssertEqual(t, IsRawFile(url), false)
+	AssertEqual(t, GetRawFile(url).String(), "http://dev.funkwhale.audio/funkwhale/ansible/raw/master/README.md")
+	AssertEqual(t, GetRawRoot(url).String(), "http://dev.funkwhale.audio/funkwhale/ansible/raw/master/")
+	AssertEqual(t, IsRawRoot(GetRawRoot(url)), true)
+	AssertEqual(t, GetRepo(url).String(), "http://dev.funkwhale.audio/funkwhale/ansible")
+	AssertEqual(t, GetRepo(GetRawRoot(url)).String(), "http://dev.funkwhale.audio/funkwhale/ansible")
+
+	// New style raw paths
+	url, _ = url.Parse("https://gitlab.com/gitlab-org/gitlab/-/raw/master/README.md")
+	AssertEqual(t, IsRawFile(url), true)
+	url, _ = url.Parse("https://gitlab.com/gitlab-org/gitlab/-/raw/master/")
+	AssertEqual(t, IsRawRoot(url), true)
+	url, _ = url.Parse("https://gitlab.com/gitlab-org/gitlab/")
+	AssertEqual(t, IsRawRoot(url), false)
+
+	// Old style raw paths
+	url, _ = url.Parse("https://riuso.comune.salerno.it/root/simel_2/raw/master/publiccode.yml")
+	AssertEqual(t, IsRawFile(url), true)
+	url, _ = url.Parse("https://riuso.comune.salerno.it/root/simel_2/raw/master/")
+	AssertEqual(t, IsRawRoot(url), true)
+	url, _ = url.Parse("https://riuso.comune.salerno.it/")
+	AssertEqual(t, IsRawRoot(url), false)
+
+	url, _ = url.Parse("https://riuso.comune.salerno.it/root/simel_2/blob/master/publiccode.yml")
+	AssertEqual(t, IsFile(url), true)
+	AssertEqual(t, IsRepo(url), false)
+	AssertEqual(t, IsRawFile(url), false)
 }
 
 // AssertEqual checks if values are equal


### PR DESCRIPTION
GitLab has started moving routes under the - scope around 12.0.
https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/config/routes/project.rb#L26
https://gitlab.com/gitlab-org/gitlab/-/issues/28848

Paths with no - are considered legacy and can be found on older versions.

Also, support plain HTTP URLs in GitLab.

italia/publiccode-parser-go#40