### PR TITLE
fix: make GetRawRoot() work properly with GitHub

### DIFF
--- a/vcsurl.go
+++ b/vcsurl.go
@@ -244,10 +244,13 @@ func GetRawRoot(url *url.URL, branch ...string) (*url.URL, error) {
 		}
 
 		if url.Host == "github.com" {
+			u := *url
+			u.Path = strings.TrimSuffix(u.Path, ".git")
+
 			root := fmt.Sprintf("https://raw.githubusercontent.com/$1/$2/%s/", defaultBranch)
 
 			re := regexp.MustCompile("^https://github.com/([^/]+)/([^/]+)$")
-			url, _ := url.Parse(re.ReplaceAllString(url.String(), root))
+			url, _ := url.Parse(re.ReplaceAllString(u.String(), root))
 
 			return url, nil
 		} else if url.Host == "bitbucket.org" {
@@ -267,8 +270,10 @@ func GetRawRoot(url *url.URL, branch ...string) (*url.URL, error) {
 // GetRepo returns the URL of the main page of the repository (i.e. not raw nor git)
 func GetRepo(url *url.URL) *url.URL {
 	if IsRepo(url) {
-		url.Path = strings.TrimSuffix(url.Path, ".git")
-		return url
+		u := *url
+		u.Path = strings.TrimSuffix(url.Path, ".git")
+
+		return &u
 	}
 	if IsFile(url) || IsRawFile(url) || IsRawRoot(url) {
 		if IsFile(url) {

--- a/vcsurl_test.go
+++ b/vcsurl_test.go
@@ -36,6 +36,12 @@ func TestGitHub(t *testing.T) {
 
 	url, _ = url.Parse("https://github.com/alranel/go-vcsurl.git")
 	AssertEqual(t, GetRepo(url).String(), "https://github.com/alranel/go-vcsurl")
+
+	// Allocate a new URL with the same address to make sure GetRawRoot() doesn't rely
+	// on previous functions changing the URL and removing the ".git" suffix.
+	//
+	// See https://github.com/alranel/go-vcsurl/pull/11
+	url, _ = url.Parse("https://github.com/alranel/go-vcsurl.git")
 	rawRoot, err = GetRawRoot(url)
 	AssertEqual(t, err, nil)
 	AssertEqual(t, rawRoot.String(), "https://raw.githubusercontent.com/alranel/go-vcsurl/master/")


### PR DESCRIPTION
GetRawRoot() failed to return the correct root when passed GitHub
URLs ending with .git (eg. https://github.com/foo/bar.git), which
are supposed to be equivalent to the same URL without ".git".

That was disguised by the fact that GetRepo() erroneously stripped
the ".git" suffix from the passed URL and made it work when called
before GetRawRoot() with the same argument.